### PR TITLE
fix: fixed issue with creating files in non-existing directory

### DIFF
--- a/scripts/create-template.js
+++ b/scripts/create-template.js
@@ -1,13 +1,23 @@
 import fs from 'fs';
 import path from 'path';
 
+const currentModuleURL = import.meta.url;
+const currentModulePath = path.dirname(new URL(currentModuleURL).pathname);
+
+const mainDirectory = path.resolve(currentModulePath, '..');
+
+const tasksDirectory = path.join(mainDirectory, 'tasks');
+
 const today = new Date();
 const year = today.getFullYear();
 const month = String(today.getMonth() + 1).padStart(2, '0');
 const day = String(today.getDate()).padStart(2, '0');
 const folderName = `${year}-${month}-${day}`;
+const folderPath = path.join(tasksDirectory, folderName);
 
-const folderPath = path.join('tasks', folderName);
+if (!fs.existsSync(tasksDirectory)) {
+    fs.mkdirSync(tasksDirectory);
+}
 
 if (!fs.existsSync(folderPath)) {
     fs.mkdirSync(folderPath);
@@ -17,8 +27,7 @@ if (!fs.existsSync(folderPath)) {
     const testFilePath = path.join(folderPath, 'index.test.ts');
     fs.writeFileSync(testFilePath, '// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`');
 
-    console.log(`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`)
+    console.log(`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`);
 } else {
     console.log(`Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`);
 }
-

--- a/scripts/create-template.js
+++ b/scripts/create-template.js
@@ -1,22 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 
-const currentModuleURL = import.meta.url;
-const currentModulePath = path.dirname(new URL(currentModuleURL).pathname);
-
-const mainDirectory = path.resolve(currentModulePath, '..');
-
-const tasksDirectory = path.join(mainDirectory, 'tasks');
-
 const today = new Date();
 const year = today.getFullYear();
 const month = String(today.getMonth() + 1).padStart(2, '0');
 const day = String(today.getDate()).padStart(2, '0');
 const folderName = `${year}-${month}-${day}`;
-const folderPath = path.join(tasksDirectory, folderName);
 
-if (!fs.existsSync(tasksDirectory)) {
-    fs.mkdirSync(tasksDirectory);
+const folderPath = path.join('tasks', folderName);
+
+if (!fs.existsSync('tasks')) {
+    fs.mkdirSync('tasks');
 }
 
 if (!fs.existsSync(folderPath)) {
@@ -27,7 +21,7 @@ if (!fs.existsSync(folderPath)) {
     const testFilePath = path.join(folderPath, 'index.test.ts');
     fs.writeFileSync(testFilePath, '// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`');
 
-    console.log(`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`);
+    console.log(`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`)
 } else {
     console.log(`Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`);
 }


### PR DESCRIPTION
Przy przejściu przez kroki na stronie przy poleceniu `npm create` pojawia się błąd:

```
node:fs:1395
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, mkdir 'tasks/2023-11-26'
    at Object.mkdirSync (node:fs:1395:3)
    at file:///Users/oskar/Repos/advent-frontend/scripts/create-template.js:13:8
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: 'tasks/2023-11-26'
}
```

Co ważne nie wiem, jak to miało wyglądać, ale katalog `tasks` tworzy się w głównym katalogu, jeśli miał się tworzyć w katalogu `scripts`, to trzeba przed zmergowaniem to zmienić ;)