### PR TITLE
feat: template create automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Zadania są dostępne na stronie [opanujfrontend.pl/advent](https://opanujfronte
 
 Każdego dnia wykonaj w repozytorium polecenie `npm run create` a następnie skopiuj kod ze strony.
 
+Użyj komendy `npm run create all`, jeśli chcesz wygenerować foldery z plikami startowymi
+na każdy z dni wyzwania.
+
+Użyj komendy `npm run create with-previous`, aby utworzyć brakujące zadania od aktualnej daty do
+dnia pierwszego wyzwania.
+
 Teraz możesz skupić się na wykonaniu zadania i weryfikacji testów poprzez polecenie `npm test`.
 
 ## 💜 Kontrybutorzy
@@ -21,7 +27,9 @@ Teraz możesz skupić się na wykonaniu zadania i weryfikacji testów poprzez po
 Nasz projekt wspierają ([zobacz typ kontrybucji](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
-  "name": "advent-of-frontend",
-  "version": "0.0.1",
-  "type": "module",
-  "description": "Szablon dla zadań z opanujfrontend.pl/advent",
-  "author": "Przeprogramowani",
-  "license": "ISC",
-  "scripts": {
-    "create": "node ./scripts/create-template.js",
-    "test": "jest ./tasks/$(date +'%Y-%m-%d')/index.test.ts",
-    "test:all": "jest"
-  },
-  "devDependencies": {
-    "@types/jest": "29.5.10",
-    "jest": "29.7.0",
-    "ts-jest": "29.1.1",
-    "tsx": "4.5.0",
-    "typescript": "5.3.2"
-  }
+	"name": "advent-of-frontend",
+	"version": "0.0.1",
+	"type": "module",
+	"description": "Szablon dla zadań z opanujfrontend.pl/advent",
+	"author": "Przeprogramowani",
+	"license": "ISC",
+	"scripts": {
+		"create": "node ./scripts/create-template.js",
+		"create-all": "node ./scripts/create-template.js all",
+		"create-previous": "node ./scripts/create-template.js with-previous",
+		"test": "jest ./tasks/$(date +'%Y-%m-%d')/index.test.ts",
+		"test:all": "jest"
+	},
+	"devDependencies": {
+		"@types/jest": "29.5.10",
+		"jest": "29.7.0",
+		"ts-jest": "29.1.1",
+		"tsx": "4.5.0",
+		"typescript": "5.3.2"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-	"name": "advent-of-frontend",
-	"version": "0.0.1",
-	"type": "module",
-	"description": "Szablon dla zadań z opanujfrontend.pl/advent",
-	"author": "Przeprogramowani",
-	"license": "ISC",
-	"scripts": {
-		"create": "node ./scripts/create-template.js",
-		"create-all": "node ./scripts/create-template.js all",
-		"create-previous": "node ./scripts/create-template.js with-previous",
-		"test": "jest ./tasks/$(date +'%Y-%m-%d')/index.test.ts",
-		"test:all": "jest"
-	},
-	"devDependencies": {
-		"@types/jest": "29.5.10",
-		"jest": "29.7.0",
-		"ts-jest": "29.1.1",
-		"tsx": "4.5.0",
-		"typescript": "5.3.2"
-	}
+  "name": "advent-of-frontend",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Szablon dla zadań z opanujfrontend.pl/advent",
+  "author": "Przeprogramowani",
+  "license": "ISC",
+  "scripts": {
+    "create": "node ./scripts/create-template.js",
+    "create-all": "node ./scripts/create-template.js all",
+    "create-previous": "node ./scripts/create-template.js with-previous",
+    "test": "jest ./tasks/$(date +'%Y-%m-%d')/index.test.ts",
+    "test:all": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.10",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "tsx": "4.5.0",
+    "typescript": "5.3.2"
+  }
 }

--- a/scripts/create-template.js
+++ b/scripts/create-template.js
@@ -4,23 +4,23 @@ import { createTaskFolder, createTaskFoldersFromRange } from "./task-folder.js";
 const arg = process.argv[2];
 
 if (!fs.existsSync("tasks")) {
-	fs.mkdirSync("tasks");
+  fs.mkdirSync("tasks");
 }
 
 if (!arg) {
-	createTaskFolder(new Date());
+  createTaskFolder(new Date());
 }
 
 if (arg === "all") {
-	const startDate = new Date("2023-12-01");
-	const endDate = new Date("2023-12-24");
+  const startDate = new Date("2023-12-01");
+  const endDate = new Date("2023-12-24");
 
-	createTaskFoldersFromRange(startDate, endDate);
+  createTaskFoldersFromRange(startDate, endDate);
 }
 
 if (arg === "with-previous") {
-	const startDate = new Date("2023-12-01");
-	const endDate = new Date();
+  const startDate = new Date("2023-12-01");
+  const endDate = new Date();
 
-	createTaskFoldersFromRange(startDate, endDate);
+  createTaskFoldersFromRange(startDate, endDate);
 }

--- a/scripts/create-template.js
+++ b/scripts/create-template.js
@@ -1,27 +1,26 @@
-import fs from 'fs';
-import path from 'path';
+import fs from "fs";
+import { createTaskFolder, createTaskFoldersFromRange } from "./task-folder.js";
 
-const today = new Date();
-const year = today.getFullYear();
-const month = String(today.getMonth() + 1).padStart(2, '0');
-const day = String(today.getDate()).padStart(2, '0');
-const folderName = `${year}-${month}-${day}`;
+const arg = process.argv[2];
 
-const folderPath = path.join('tasks', folderName);
-
-if (!fs.existsSync('tasks')) {
-    fs.mkdirSync('tasks');
+if (!fs.existsSync("tasks")) {
+	fs.mkdirSync("tasks");
 }
 
-if (!fs.existsSync(folderPath)) {
-    fs.mkdirSync(folderPath);
-    const indexFilePath = path.join(folderPath, 'index.ts');
-    fs.writeFileSync(indexFilePath, '// Tutaj skopiuj kod zadania');
+if (!arg) {
+	createTaskFolder(new Date());
+}
 
-    const testFilePath = path.join(folderPath, 'index.test.ts');
-    fs.writeFileSync(testFilePath, '// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`');
+if (arg === "all") {
+	const startDate = new Date("2023-12-01");
+	const endDate = new Date("2023-12-24");
 
-    console.log(`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`)
-} else {
-    console.log(`Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`);
+	createTaskFoldersFromRange(startDate, endDate);
+}
+
+if (arg === "with-previous") {
+	const startDate = new Date("2023-12-01");
+	const endDate = new Date();
+
+	createTaskFoldersFromRange(startDate, endDate);
 }

--- a/scripts/task-folder.js
+++ b/scripts/task-folder.js
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+
+export function getFolderName(date) {
+	if (!date) {
+		date = new Date();
+	}
+
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	const folderName = `${year}-${month}-${day}`;
+
+	return folderName;
+}
+
+export function createTaskFolder(date = new Date()) {
+	const folderName = getFolderName(date);
+	const folderPath = path.join("tasks", folderName);
+
+	if (!fs.existsSync(folderPath)) {
+		fs.mkdirSync(folderPath);
+		const indexFilePath = path.join(folderPath, "index.ts");
+		fs.writeFileSync(indexFilePath, "// Tutaj skopiuj kod zadania");
+
+		const testFilePath = path.join(folderPath, "index.test.ts");
+		fs.writeFileSync(
+			testFilePath,
+			"// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`"
+		);
+
+		console.log(
+			`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`
+		);
+	} else {
+		console.log(
+			`Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`
+		);
+	}
+}
+
+export function createTaskFoldersFromRange(startDate, endDate) {
+	for (
+		let date = startDate;
+		date <= endDate;
+		date.setDate(date.getDate() + 1)
+	) {
+		createTaskFolder(new Date(date));
+	}
+}

--- a/scripts/task-folder.js
+++ b/scripts/task-folder.js
@@ -2,49 +2,49 @@ import fs from "fs";
 import path from "path";
 
 export function getFolderName(date) {
-	if (!date) {
-		date = new Date();
-	}
+  if (!date) {
+    date = new Date();
+  }
 
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, "0");
-	const day = String(date.getDate()).padStart(2, "0");
-	const folderName = `${year}-${month}-${day}`;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const folderName = `${year}-${month}-${day}`;
 
-	return folderName;
+  return folderName;
 }
 
 export function createTaskFolder(date = new Date()) {
-	const folderName = getFolderName(date);
-	const folderPath = path.join("tasks", folderName);
+  const folderName = getFolderName(date);
+  const folderPath = path.join("tasks", folderName);
 
-	if (!fs.existsSync(folderPath)) {
-		fs.mkdirSync(folderPath);
-		const indexFilePath = path.join(folderPath, "index.ts");
-		fs.writeFileSync(indexFilePath, "// Tutaj skopiuj kod zadania");
+  if (!fs.existsSync(folderPath)) {
+    fs.mkdirSync(folderPath);
+    const indexFilePath = path.join(folderPath, "index.ts");
+    fs.writeFileSync(indexFilePath, "// Tutaj skopiuj kod zadania");
 
-		const testFilePath = path.join(folderPath, "index.test.ts");
-		fs.writeFileSync(
-			testFilePath,
-			"// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`"
-		);
+    const testFilePath = path.join(folderPath, "index.test.ts");
+    fs.writeFileSync(
+      testFilePath,
+      "// Tutaj skopiuj testy dla zadania. Uruchom je poleceniem `npm test`"
+    );
 
-		console.log(
-			`Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`
-		);
-	} else {
-		console.log(
-			`Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`
-		);
-	}
+    console.log(
+      `Przygotowano szablon na zadanie w folderze tasks/${folderName} 🎄`
+    );
+  } else {
+    console.log(
+      `Folder na dzisiejsze zadania już istnieje (tasks/${folderName}) 🤔`
+    );
+  }
 }
 
 export function createTaskFoldersFromRange(startDate, endDate) {
-	for (
-		let date = startDate;
-		date <= endDate;
-		date.setDate(date.getDate() + 1)
-	) {
-		createTaskFolder(new Date(date));
-	}
+  for (
+    let date = startDate;
+    date <= endDate;
+    date.setDate(date.getDate() + 1)
+  ) {
+    createTaskFolder(new Date(date));
+  }
 }


### PR DESCRIPTION
I have created a more advanced template automation inside create-template.js script. I added two extra script paths with parameters usage. The `all` parameter will create tasks for whole event and `with-previous` do it from relative "today" to the event start date.

Also I have prepared the npm scripts for these parameters and updated the `README.md` docs. 